### PR TITLE
223 corrections for right decision for MSI-ReinstallMode

### DIFF
--- a/Deploy-Application.ps1
+++ b/Deploy-Application.ps1
@@ -199,6 +199,8 @@ function Main {
 					CustomInstallAndReinstallPreInstallAndReinstall
 					[string]$script:installPhase = 'Decide-ReInstallMode'
 					if ($true -eq $(Test-NxtAppIsInstalled -DeploymentMethod $InstallMethod)) {
+						## because it could be manipulated by last call of Test-NxtAppIsInstalled re-read this parameter here
+						[string]$ReinstallMode = $global:PackageConfig.ReinstallMode
 						Write-Log -Message "[$script:installPhase] selected Mode: $ReinstallMode" -Source $deployAppScriptFriendlyName
 						switch ($ReinstallMode) {
 							"Reinstall" {

--- a/neo42PackageConfig.json
+++ b/neo42PackageConfig.json
@@ -6,6 +6,8 @@
   "InstallMethod": "Inno Setup",
   "UninstallMethod": "Inno Setup",
   "ReinstallMode": "Reinstall",
+  "MSIInplaceUpgradable": true,
+  "MSIDowngradeable": false,
   "TestedOn": "Win10 x64",
   "Dependencies": "",
   "LastChange": "22/09/2022",


### PR DESCRIPTION
This is a temporary workaround.

We should move this decision to a separate function like Switch-NxtMSIReinstallMode, which sets the needed ReinstallMode for actual machine state depending of comparison of found and new display version (note: MSIRepair may be used for same installed version only!).
For this we have to change the functionality for DetectedDisplayVersion. The actual installed display version should be able to get at any time and not only at beginning of script. Because function Uninstall-NxtOld may change the current state for it. To switch the ReinstallMode exactly we need the installed display version at this time in script execution.
For instance the global variable DetectedDisplayVersion (like initially detected display version, if possibly needed later?) may set in base script via changed function Get-NxtDetectedDisplayVersion (then named to Get-NxtCurrentDisplayVersion?)