### PR TITLE
232 show nxtinstallationwelcome fails when a process is in list appkillprocesses is running or list is empty

### DIFF
--- a/AppDeployToolkit/AppDeployToolkitExtensions.ps1
+++ b/AppDeployToolkit/AppDeployToolkitExtensions.ps1
@@ -5422,7 +5422,7 @@ Function Show-NxtInstallationWelcome {
 			}
 			elseif ([System.Management.Automation.WildcardPattern]::ContainsWildcardCharacters($processAppsItem.Name)) {				
 				Write-Log -Message "Wildcard in list entry for 'CloseApps' process collection detected, retrieving all matching running processes for '$($processAppsItem.Name)' ..." -Source ${cmdletName}
-				# Get-WmiObject always needs an extension, so let's add one for sure
+				## Get-WmiObject Win32_Process always requires an extension, so we add one in case there is none
 				[string]$processAppsItem.Name = $($processAppsItem.Name -replace "\$fileExtension$","") + $fileExtension
 				[string]$processAppsItem.Name = (($(Get-WmiObject -Query "Select * from Win32_Process Where Name LIKE '$(($processAppsItem.Name).Replace("*","%"))'").name) -replace "\$fileExtension$","") -join ","
 				if ( [String]::IsNullOrEmpty($processAppsItem.Name) ) {


### PR DESCRIPTION
Note: Scriptblock-Variablename is changed now to $FillCloseAppl**i**cationList, was written with an 'a' before (..Applacation..) ... ;)

Possibly we have to discuss the behavior, when hidden processes are in list of appstokill! Actually just a log message is written, hopefully a packager is testing the package and change it, if it happens like this: NO process is shown in message window for the user in this case!!! :)