### PR TITLE
305 created example script

### DIFF
--- a/Samples/example_SnippetForMultipleSetupsInCustomBegin.ps1
+++ b/Samples/example_SnippetForMultipleSetupsInCustomBegin.ps1
@@ -15,29 +15,29 @@ function CustomBegin {
 
     ############################################
 	## EXAMPLE 1 ##
-	## decision for usage of a custom setup file by pre-defined registry value set by GPO for example
+	## decision for usage of an alternative setup file by pre-defined registry value set by GPO for example
 
 	## please fill in here real used values
 	[string]$regKeySetByGPO = "HKLM:\SOFTWARE\Policies\packages\<PackageGUID>"
-	[string]$regValueSetByGPO = "CustomSetupFileName"
+	[string]$regValueSetByGPO = "SetupFileNameToUse"
 
-	[string]$customSetupFileName = Get-RegistryKey -Key "$regKeySetByGPO" -Value "$regValueSetByGPO"
-	if (![string]::IsNullOrEmpty($customSetupFileName)) {
-		Set-NxtSetupCfg -Path "$PSScriptRoot\$customSetupFileName"
-		if ($false -eq (Test-Path -Path "$PSScriptRoot\$customSetupFileName")) {
+	[string]$alternativeSetupCfg = Get-RegistryKey -Key "$regKeySetByGPO" -Value "$regValueSetByGPO"
+	if (![string]::IsNullOrEmpty($alternativeSetupCfg)) {
+		Set-NxtSetupCfg -Path "$PSScriptRoot\$alternativeSetupCfg"
+		if ($false -eq (Test-Path -Path "$PSScriptRoot\$alternativeSetupCfg")) {
 			## alternatively, if necessary you can stop script execution commonly here: uncomment next line
 			#Exit-NxtScriptWithError -ErrorMessage "The installation/uninstallation aborted with an invalid file decision!" -MainExitCode '60001'
 		}
 	}
 	else {
-		Write-Log -Message "No or invalid registry key/value for a custom setup file defined." -Severity 3 -Source $deployAppScriptFriendlyName
+		Write-Log -Message "No or invalid registry key/value for an alternative setup file defined." -Severity 3 -Source $deployAppScriptFriendlyName
 		## alternatively, if necessary you can stop script execution here: uncomment next line
 		#Exit-NxtScriptWithError -ErrorMessage "The installation/uninstallation aborted with an invalid pre-configuration!" -MainExitCode '60001'
 	}
 
 	############################################
 	## EXAMPLE 2 ##
-	## decision for usage of a custom setup file by set an environment variable value for example
+	## decision for usage of an alternative setup file by set an environment variable value for example
 
 	## please fill in here real used values
 	[string]$decision = $env:Department
@@ -45,30 +45,30 @@ function CustomBegin {
 	## please fill in and/or add/remove here real used decisions
 	switch ($decision) {
 		{"<department_A>","<department_B>" -contains $_} {
-			[string]$customSetupFile = "$PSScriptRoot\Setup_AB.cfg"
+			[string]$alternativeSetupCfg = "$PSScriptRoot\Setup_AB.cfg"
 		}
 		## ... just simply for a single value
 		"<department_C>" {
-			[string]$customSetupFile = "$PSScriptRoot\Setup_C.cfg"
+			[string]$alternativeSetupCfg = "$PSScriptRoot\Setup_C.cfg"
 		}
 		Default {
-			[string]$customSetupFile = $null
-			Write-Log -Message "No custom setup file defined for current selection [$decision]." -Severity 3 -Source $deployAppScriptFriendlyName
+			[string]$alternativeSetupCfg = $null
+			Write-Log -Message "No alternative setup file defined for current selection [$decision]." -Severity 3 -Source $deployAppScriptFriendlyName
 			## alternatively, if necessary you can stop script execution here: uncomment next line
 			#Exit-NxtScriptWithError -ErrorMessage "The installation/uninstallation aborted with an invalid file decision!" -MainExitCode '60001'
 		}
 	}
-	if (![string]::IsNullOrEmpty($customSetupFile)) {
-		Set-NxtSetupCfg -Path "$customSetupFile"
-		if ($false -eq (Test-Path -Path "$customSetupFile")) {
+	if (![string]::IsNullOrEmpty($alternativeSetupCfg)) {
+		Set-NxtSetupCfg -Path "$alternativeSetupCfg"
+		if ($false -eq (Test-Path -Path "$alternativeSetupCfg")) {
 			## alternatively, if necessary you can stop script execution commonly here: uncomment next line
-			#Exit-NxtScriptWithError -ErrorMessage "The installation/uninstallation aborted with an invalid custom setup file selection!" -MainExitCode '60001'
+			#Exit-NxtScriptWithError -ErrorMessage "The installation/uninstallation aborted with an invalid alternative setup file selection!" -MainExitCode '60001'
 		}
 	}
 
 	############################################
 	## EXAMPLE 3 ##
-	## decision for usage of a custom setup file by set an environment variable value and direct usage of value for file name as fastest solution for example
+	## decision for usage of an alternative setup file by set an environment variable value and direct usage of value for file name as fastest solution for example
 
 	## please fill in here real used values
 	[string]$decision = $env:Department
@@ -77,11 +77,11 @@ function CustomBegin {
 		Set-NxtSetupCfg -Path "$PSScriptRoot\$decision.cfg"
 		if ($false -eq (Test-Path -Path "$PSScriptRoot\$decision.cfg")) {
 			## alternatively, if necessary you can stop script execution commonly here: uncomment next line
-			#Exit-NxtScriptWithError -ErrorMessage "The installation/uninstallation aborted with an invalid custom setup file selection!" -MainExitCode '60001'
+			#Exit-NxtScriptWithError -ErrorMessage "The installation/uninstallation aborted with an invalid alternative setup file selection!" -MainExitCode '60001'
 		}
 	}
 	else {
-		Write-Log -Message "Invalid decision for a custom setup file defined." -Severity 3 -Source $deployAppScriptFriendlyName
+		Write-Log -Message "Invalid decision for an alternative setup file defined." -Severity 3 -Source $deployAppScriptFriendlyName
 		## alternatively, if necessary you can stop script execution here: uncomment next line
 		#Exit-NxtScriptWithError -ErrorMessage "The installation/uninstallation aborted with an invalid pre-configuration!" -MainExitCode '60001'
     }


### PR DESCRIPTION
I think it makes no sense to change the real used setup.cfg... instead we additionally parse the named custom setup.cfg. This overrides all values previously readed from default setup.cfg - same procedure like with default CustomSetup.cfg after issue #324.
Possibly we change the 'Set-NxtSetupCfg' into 'Set-NxtCustomSetupCfg' in the examples -> this makes sense if the issue #324 is merged, because there are some necessary changes for this functionality included!