### PR TITLE
new setup.cfg handling in $App

### DIFF
--- a/AppDeployToolkit/AppDeployToolkitExtensions.ps1
+++ b/AppDeployToolkit/AppDeployToolkitExtensions.ps1
@@ -624,8 +624,8 @@ function Complete-NxtPackageInstallation {
 			Copy-File -Path "$dirSupportFiles\$UserpartDir\*" -Destination "$App\$UserpartDir\SupportFiles" -Recurse
 			Copy-File -Path "$scriptRoot\$($xmlConfigFile.GetElementsByTagName('BannerIcon_Options').Icon_Filename)" -Destination "$App\$UserpartDir\"
 			Copy-item -Path "$scriptDirectory\*" -Exclude "Files", "SupportFiles" -Destination "$App\$UserpartDir\" -Recurse -Force -ErrorAction Continue
-			if ($true -eq (Test-Path -Path "$App\Setup.cfg")){
-				Copy-File -Path "$App\Setup.cfg" -Destination "$App\$UserpartDir\"
+			if ($true -eq (Test-Path -Path "$App\neo42-Install\Setup.cfg")){
+				Copy-File -Path "$App\neo42-Install\Setup.cfg" -Destination "$App\$UserpartDir\"
 			}
 			Write-NxtSingleXmlNode -XmlFilePath "$App\$UserpartDir\$(Split-Path "$scriptRoot" -Leaf)\$(Split-Path "$appDeployConfigFile" -Leaf)" -SingleNodeName "//Toolkit_RequireAdmin" -Value "False"
 			Write-NxtSingleXmlNode -XmlFilePath "$App\$UserpartDir\$(Split-Path "$scriptRoot" -Leaf)\$(Split-Path "$appDeployConfigFile" -Leaf)" -SingleNodeName "//ShowBalloonNotifications" -Value "False"
@@ -701,8 +701,8 @@ function Complete-NxtPackageUninstallation {
 			Copy-File -Path "$dirSupportFiles\$UserpartDir\*" -Destination "$App\$UserpartDir\SupportFiles" -Recurse
 			Copy-File -Path "$scriptRoot\$($xmlConfigFile.GetElementsByTagName('BannerIcon_Options').Icon_Filename)" -Destination "$App\$UserpartDir\"
 			Copy-item -Path "$scriptDirectory\*" -Exclude "Files", "SupportFiles" -Destination "$App\$UserpartDir\" -Recurse -Force -ErrorAction Continue
-			if ($true -eq (Test-Path -Path "$App\Setup.cfg")){
-				Copy-File -Path "$App\Setup.cfg" -Destination "$App\$UserpartDir\"
+			if ($true -eq (Test-Path -Path "$App\neo42-Install\Setup.cfg")){
+				Copy-File -Path "$App\neo42-Install\Setup.cfg" -Destination "$App\$UserpartDir\"
 			}
 			Write-NxtSingleXmlNode -XmlFilePath "$App\$UserpartDir\$(Split-Path "$scriptRoot" -Leaf)\$(Split-Path "$appDeployConfigFile" -Leaf)" -SingleNodeName "//Toolkit_RequireAdmin" -Value "False"
 			Write-NxtSingleXmlNode -XmlFilePath "$App\$UserpartDir\$(Split-Path "$scriptRoot" -Leaf)\$(Split-Path "$appDeployConfigFile" -Leaf)" -SingleNodeName "//ShowBalloonNotifications" -Value "False"


### PR DESCRIPTION
setup cfg override is allways imported to $app and will be used instead of the shipped setup.cfg