### PR TITLE
630 get nxtinifilewithcomments throws when specifing global variables

### DIFF
--- a/AppDeployToolkit/AppDeployToolkitExtensions.ps1
+++ b/AppDeployToolkit/AppDeployToolkitExtensions.ps1
@@ -4935,8 +4935,8 @@ function Import-NxtIniFile {
 	}
 	Process {
 		try {
-			[hashtable]$ini = @{}
-			[string]$section = ''
+			[hashtable]$ini = @{default=@{}}
+			[string]$section = 'default'
 			[Array]$content = Get-Content -Path $Path
 			foreach ($line in $content) {
 				if ($line -match '^\[(.+)\]$') {
@@ -4951,12 +4951,11 @@ function Import-NxtIniFile {
 				elseif ($line -match '^(.+?)\s*=\s*(.*)$') {
 					[string]$variableName = $matches[1]
 					[string]$value = $matches[2].Trim()
-					if ($false -eq $section){
-						Write-Log -Message "Section for variable '$variableName' has not been specified. Skipping assignment." -Severity 2 -Source ${CmdletName}
-						continue
-					}
 					[string]$ini[$section][$variableName] = $value
 				}
+			}
+			if ($ini.default.count -eq 0) {
+				$ini.Remove('default')
 			}
 			Write-Output $ini
 			Write-Log -Message "Read ini file [$path]. " -Source ${CmdletName}
@@ -5010,8 +5009,8 @@ function Import-NxtIniFileWithComments {
 	}
 	Process {
 		try {
-			[hashtable]$ini = @{}
-			[string]$section = ''
+			[hashtable]$ini = @{default=@{}}
+			[string]$section = 'default'
 			[array]$commentBuffer = @()
 			[Array]$content = Get-Content -Path $Path
 			foreach ($line in $content) {
@@ -5027,16 +5026,15 @@ function Import-NxtIniFileWithComments {
 				elseif ($line -match '^(.+?)\s*=\s*(.*)$') {
 					[string]$variableName = $matches[1]
 					[string]$value = $matches[2].Trim()
-					if ($false -eq $section){
-						Write-Log -Message "Section for variable '$variableName' has not been specified. Skipping assignment." -Severity 2 -Source ${CmdletName}
-						continue
-					}
 					[hashtable]$ini[$section][$variableName] = @{
 						Value    = $value
 						Comments = $commentBuffer -join "`r`n"
 					}
 					[array]$commentBuffer = @()
 				}
+			}
+			if ($ini.default.count -eq 0) {
+				$ini.Remove('default')
 			}
 			Write-Output $ini
 			Write-Log -Message "Read ini file [$path]. " -Source ${CmdletName}

--- a/test/Definitions/Import-NxtIniFile.Tests.ps1
+++ b/test/Definitions/Import-NxtIniFile.Tests.ps1
@@ -69,7 +69,9 @@ file = "payroll.dat"
             $result = Import-NxtIniFile -Path $PSScriptRoot\test.ini -ContinueOnError $true
 
             # Test global variables
-            $result.GetEnumerator().Name | Should -Not -Contain 'info'
+            $result.GetEnumerator().Name | Should -Contain 'default'
+            $result.default.GetEnumerator().Name | Should -Contain 'info'
+            $result.default.info | Should -Be 'Global info'
 
             # Test delimiter
             $result.owner.GetEnumerator().Name | Should -Not -Contain 'name'

--- a/test/Definitions/Import-NxtIniFileWithComments.ps1
+++ b/test/Definitions/Import-NxtIniFileWithComments.ps1
@@ -72,6 +72,11 @@ file = "payroll.dat"
         It "Should return a hashtable of the INI file contents" {
             $result = Import-NxtIniFileWithComments -Path $PSScriptRoot\test.ini
 
+             # Test global variables
+            $result.GetEnumerator().Name | Should -Contain 'default'
+            $result.default.GetEnumerator().Name | Should -Contain 'info'
+            $result.default.info.value | Should -Be 'Global info'
+
             # Test delimiter
             $result.owner.GetEnumerator().Name | Should -Not -Contain 'name'
 


### PR DESCRIPTION
Remove nonfunctional assignment to 'default' section and replaced with warning

Added global variables to test inis