### PR TITLE
874 rootpathtorecurseupto missing in many clean neo42appfolderps1 calls

### DIFF
--- a/AppDeployToolkit/AppDeployToolkitExtensions.ps1
+++ b/AppDeployToolkit/AppDeployToolkitExtensions.ps1
@@ -1290,15 +1290,15 @@ function Complete-NxtPackageInstallation {
 				Path = 'powershell.exe'
 				Parameters = "-ExecutionPolicy $ExecutionPolicy -File `"$oldAppFolder\Clean-Neo42AppFolder.ps1`""
 				NoWait = $true
-				WorkingDirectory = $AppRootFolder
+				WorkingDirectory = $env:TEMP
 				ExitOnProcessFailure = $false
 				PassThru = $true
 			}
-			## we use AppRootFolder es workingdirectory to avoid issues with locked directories
+			## we use $env:temp es workingdirectory to avoid issues with locked directories
 			if (
 				$false -eq [string]::IsNullOrEmpty($AppRootFolder) -and
 				$false -eq [string]::IsNullOrEmpty($AppVendor)
-				) {
+			) {
 				$executeProcessSplat["Parameters"] = Add-NxtParameterToCommand -Command $executeProcessSplat["Parameters"] -Name "RootPathToRecurseUpTo" -Value "$AppRootFolder\$AppVendor"
 			}
 			Execute-Process @executeProcessSplat | Out-Null
@@ -11712,15 +11712,15 @@ function Unregister-NxtPackage {
 									Path = 'powershell.exe'
 									Parameters = "-ExecutionPolicy $ExecutionPolicy -File `"$assignedPackageGUIDAppPath\Clean-Neo42AppFolder.ps1`""
 									NoWait = $true
-									WorkingDirectory = $AppRootFolder
+									WorkingDirectory = $env:TEMP
 									ExitOnProcessFailure = $false
 									PassThru = $true
 								}
-								## we use AppRootFolder es workingdirectory to avoid issues with locked directories
+								## we use $env:TEMP es workingdirectory to avoid issues with locked directories
 								if (
 									$false -eq [string]::IsNullOrEmpty($AppRootFolder) -and
 									$false -eq [string]::IsNullOrEmpty($AppVendor)
-									) {
+								) {
 									$executeProcessSplat["Parameters"] = Add-NxtParameterToCommand -Command $executeProcessSplat["Parameters"] -Name "RootPathToRecurseUpTo" -Value "$AppRootFolder\$AppVendor"
 								}
 								Execute-Process @executeProcessSplat | Out-Null
@@ -11762,11 +11762,11 @@ function Unregister-NxtPackage {
 							Path = 'powershell.exe'
 							Parameters = "-ExecutionPolicy $ExecutionPolicy -File `"$App\Clean-Neo42AppFolder.ps1`""
 							NoWait = $true
-							WorkingDirectory = $AppRootFolder
+							WorkingDirectory = $env:TEMP
 							ExitOnProcessFailure = $false
 							PassThru = $true
 						}
-						## we use AppRootFolder es workingdirectory to avoid issues with locked directories
+						## we use $env:TEMP es workingdirectory to avoid issues with locked directories
 						if (
 							$false -eq [string]::IsNullOrEmpty($AppRootFolder) -and
 							$false -eq [string]::IsNullOrEmpty($AppVendor)


### PR DESCRIPTION
testszenario:
1. Install
2. Change AppVersion
3. Set UninstallOld to False
4. Install
-> there should only be 1 App Folder (other Versions than the current installed should be gone if empty)