### PR TITLE
Add Encoding parameter to Get-Content

### DIFF
--- a/Deploy-Application.ps1
+++ b/Deploy-Application.ps1
@@ -221,7 +221,7 @@ Remove-Variable -Name 'tempLoadPackageConfig'
 ##* Do not modify section below =============================================================================================================================================
 #region DoNotModify
 ## Set the script execution policy for this process
-[xml]$tempLoadToolkitConfig = Get-Content -Raw -Path "$global:AppDeployToolkitConfigPath"
+[xml]$tempLoadToolkitConfig = Get-Content -Raw -Encoding 'UTF8' -Path "$global:AppDeployToolkitConfigPath"
 [string]$powerShellOptionsExecutionPolicy = $tempLoadToolkitConfig.AppDeployToolkit_Config.NxtPowerShell_Options.NxtPowerShell_ExecutionPolicy
 if (($true -eq [string]::IsNullOrEmpty($powerShellOptionsExecutionPolicy)) -or ([Enum]::GetNames([Microsoft.Powershell.ExecutionPolicy]) -notcontains $powerShellOptionsExecutionPolicy)) {
 	Write-Error -Message "Invalid value for 'Toolkit_ExecutionPolicy' property in 'AppDeployToolkitConfig.xml'."


### PR DESCRIPTION
Due to some config missing the Byte Order Mark we now simply assume it to be UTF8 as this is a hard requirement of PSADTv3 anyway